### PR TITLE
BBCodeでカラーコードに対応

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -234,6 +234,14 @@ class Formatter
           :quick_param_format => /(2x|3x|4x|5x)/,
           :quick_param_format_description => 'The size parameter \'%param%\' is incorrect, a number is expected',
           :param_tokens => [{:token => :size}]},
+        :colorhex => {
+          :html_open => '<span style="color: #%colorcode%">', :html_close => '</span>',
+          :description => 'Use color code',
+          :example => '[colorhex=ffffff]White text[/large]',
+          :allow_quick_param => true, :allow_between_as_param => false,
+          :quick_param_format => /([0-9a-fA-F]{6})/,
+          :quick_param_format_description => 'The size parameter \'%param%\' is incorrect, a number is expected',
+          :param_tokens => [{:token => :colorcode}]},
       }, :enable, :i, :b, :color, :quote, :code, :size, :u, :s, :spin, :pulse, :flip, :large)
     rescue Exception => e
     end

--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -237,12 +237,12 @@ class Formatter
         :colorhex => {
           :html_open => '<span style="color: #%colorcode%">', :html_close => '</span>',
           :description => 'Use color code',
-          :example => '[colorhex=ffffff]White text[/large]',
+          :example => '[colorhex=ffffff]White text[/colorhex]',
           :allow_quick_param => true, :allow_between_as_param => false,
           :quick_param_format => /([0-9a-fA-F]{6})/,
-          :quick_param_format_description => 'The size parameter \'%param%\' is incorrect, a number is expected',
+          :quick_param_format_description => 'The size parameter \'%param%\' is incorrect',
           :param_tokens => [{:token => :colorcode}]},
-      }, :enable, :i, :b, :color, :quote, :code, :size, :u, :s, :spin, :pulse, :flip, :large)
+      }, :enable, :i, :b, :color, :quote, :code, :size, :u, :s, :spin, :pulse, :flip, :large, :colorhex)
     rescue Exception => e
     end
     html


### PR DESCRIPTION
`[colorhex=A55A4A][large=3x]まつざきしげるいろ■[/large][/colorhex]`   

![323fd545045b5002565c5cebd07fc453](https://user-images.githubusercontent.com/14953122/30745520-80b59cb8-9fe1-11e7-8234-0581ae18050a.png)
