### PR TITLE
パスがハードコーディングされていた箇所を修正

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,5 +1,6 @@
 threads_count = ENV.fetch('MAX_THREADS') { 5 }.to_i
 threads threads_count, threads_count
+application_path = "#{File.expand_path("../..", __FILE__)}"
 
 if ENV['SOCKET'] then
   bind 'unix://' + ENV['SOCKET']
@@ -16,6 +17,6 @@ on_worker_boot do
   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
 end
 
-stdout_redirect '/home/mastodon/live/log/stdout', '/home/mastodon/live/log/stderr', true
+stdout_redirect "#{application_path}/log/stdout", "#{application_path}/log/stderr", true
 
 plugin :tmp_restart


### PR DESCRIPTION
特定のパスに設置しないと起動に失敗するようになっていたため、カレントディレクトリを基準とするよう修正しました