### PR TITLE
WebUIで他アカウントのトゥートのピン留め表記が出ない問題を修正

### DIFF
--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -3,12 +3,11 @@
 class REST::StatusSerializer < ActiveModel::Serializer
   attributes :id, :created_at, :in_reply_to_id, :in_reply_to_account_id,
              :sensitive, :spoiler_text, :visibility, :language,
-             :uri, :content, :url, :reblogs_count, :favourites_count, :enquete
+             :uri, :content, :url, :reblogs_count, :favourites_count, :enquete, :pinned
 
   attribute :favourited, if: :current_user?
   attribute :reblogged, if: :current_user?
   attribute :muted, if: :current_user?
-  attribute :pinned, if: :pinnable?
 
   belongs_to :reblog, serializer: REST::StatusSerializer
   belongs_to :application
@@ -77,11 +76,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   end
 
   def pinned
-    if instance_options && instance_options[:relationships]
-      instance_options[:relationships].pins_map[object.id] || false
-    else
-      current_user.account.pinned?(object)
-    end
+    StatusPin.where(status_id: object.id).where(account_id: object.account_id).count > 0
   end
 
   def pinnable?


### PR DESCRIPTION
他ユーザーのトゥート一覧のレスポンスにpinnedが含まれていなかったため該当する箇所の修正を行いました。 (Issue #29)

※リファクタリングは任せた！！