### PR TITLE
embedのカスタム絵文字をoriginalに

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -111,7 +111,7 @@ class Formatter
   def encode_custom_emojis(html, emojis)
     return html if emojis.empty?
 
-    emoji_map = emojis.map { |e| [e.shortcode, full_asset_url(e.image.url(:static))] }.to_h
+    emoji_map = emojis.map { |e| [e.shortcode, full_asset_url(e.image.url)] }.to_h
 
     i                     = -1
     inside_tag            = false


### PR DESCRIPTION
今の状態だと動くカスタム絵文字が動かない為、staticからoriginalに変更

[![https://yuzu.gyazo.com/2bbdba04868fd6ef927c30e5f0f9917a](https://t.gyazo.com/teams/yuzu/2bbdba04868fd6ef927c30e5f0f9917a.gif)](https://yuzu.gyazo.com/2bbdba04868fd6ef927c30e5f0f9917a)