### PR TITLE
単一カラムモードから複数カラムモードへの切り替えに関する不具合の修正

### DIFF
--- a/app/javascript/styles/dark/components.scss
+++ b/app/javascript/styles/dark/components.scss
@@ -1572,7 +1572,7 @@
   }
 }
 
-@media screen and (max-width: 630px) {
+@media screen and (max-width: 1024px) {
   .column,
   .drawer {
     width: 100%;
@@ -1589,7 +1589,7 @@
   }
 }
 
-@media screen and (min-width: 631px) {
+@media screen and (min-width: 1025px) {
   .columns-area {
     padding: 0;
   }
@@ -1703,7 +1703,7 @@
   &:hover,
   &:focus,
   &:active {
-    @media screen and (min-width: 631px) {
+    @media screen and (min-width: 1025px) {
       background: lighten($ui-base-color, 14%);
       transition: all 100ms linear;
     }
@@ -1723,7 +1723,7 @@
   }
 }
 
-@media screen and (min-width: 631px) {
+@media screen and (min-width: 1025px) {
   .tabs-bar {
     display: none;
   }
@@ -4299,7 +4299,7 @@ noscript {
   100% { opacity: 1; }
 }
 
-@media screen and (max-width: 630px) and (max-height: 400px) {
+@media screen and (max-width: 1024px) and (max-height: 400px) {
   $duration: 400ms;
   $delay: 100ms;
 

--- a/app/javascript/styles/dark/rtl.scss
+++ b/app/javascript/styles/dark/rtl.scss
@@ -231,7 +231,7 @@ body.rtl {
     margin-left: 30px;
   }
 
-  @media screen and (min-width: 631px) {
+  @media screen and (min-width: 1025px) {
     .column,
     .drawer {
       padding-left: 5px;

--- a/app/javascript/styles/electronic/components.scss
+++ b/app/javascript/styles/electronic/components.scss
@@ -1576,7 +1576,7 @@
   }
 }
 
-@media screen and (max-width: 630px) {
+@media screen and (max-width: 1024px) {
   .column,
   .drawer {
     width: 100%;
@@ -1593,7 +1593,7 @@
   }
 }
 
-@media screen and (min-width: 631px) {
+@media screen and (min-width: 1025px) {
   .columns-area {
     padding: 0;
   }
@@ -1707,7 +1707,7 @@
   &:hover,
   &:focus,
   &:active {
-    @media screen and (min-width: 631px) {
+    @media screen and (min-width: 1025px) {
       background: lighten($ui-base-color, 14%);
       transition: all 100ms linear;
     }
@@ -1727,7 +1727,7 @@
   }
 }
 
-@media screen and (min-width: 631px) {
+@media screen and (min-width: 1025px) {
   .tabs-bar {
     display: none;
   }
@@ -4303,7 +4303,7 @@ noscript {
   100% { opacity: 1; }
 }
 
-@media screen and (max-width: 630px) and (max-height: 400px) {
+@media screen and (max-width: 1024px) and (max-height: 400px) {
   $duration: 400ms;
   $delay: 100ms;
 

--- a/app/javascript/styles/electronic/rtl.scss
+++ b/app/javascript/styles/electronic/rtl.scss
@@ -231,7 +231,7 @@ body.rtl {
     margin-left: 30px;
   }
 
-  @media screen and (min-width: 631px) {
+  @media screen and (min-width: 1025px) {
     .column,
     .drawer {
       padding-left: 5px;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1572,7 +1572,7 @@
   }
 }
 
-@media screen and (max-width: 630px) {
+@media screen and (max-width: 1024px) {
   .column,
   .drawer {
     width: 100%;
@@ -1589,7 +1589,7 @@
   }
 }
 
-@media screen and (min-width: 631px) {
+@media screen and (min-width: 1025px) {
   .columns-area {
     padding: 0;
   }
@@ -1703,7 +1703,7 @@
   &:hover,
   &:focus,
   &:active {
-    @media screen and (min-width: 631px) {
+    @media screen and (min-width: 1025px) {
       background: lighten($ui-base-color, 14%);
       transition: all 100ms linear;
     }
@@ -1723,7 +1723,7 @@
   }
 }
 
-@media screen and (min-width: 631px) {
+@media screen and (min-width: 1025px) {
   .tabs-bar {
     display: none;
   }
@@ -4299,7 +4299,7 @@ noscript {
   100% { opacity: 1; }
 }
 
-@media screen and (max-width: 630px) and (max-height: 400px) {
+@media screen and (max-width: 1024px) and (max-height: 400px) {
   $duration: 400ms;
   $delay: 100ms;
 

--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -231,7 +231,7 @@ body.rtl {
     margin-left: 30px;
   }
 
-  @media screen and (min-width: 631px) {
+  @media screen and (min-width: 1025px) {
     .column,
     .drawer {
       padding-left: 5px;


### PR DESCRIPTION
神崎丼では <https://github.com/tootsuite/mastodon/pull/5063> を無効化していると記憶していましたが、現在Production環境へ反映されているコードではSassのみ本家と同じ横幅(631px)で単一カラムモードと複数カラムモードの切り替えが行われる状態となっていました。
※おそらく <https://github.com/tootsuite/mastodon/pull/5336> が入ったタイミング？

このPull RequestではSass側の書き換えを行い、ウィンドウ幅変更時に正しくスタイルが適用されるよう修正を加えました。